### PR TITLE
Remove misleading comment w.r.t. number classification

### DIFF
--- a/Lab2-Computer-Vision.ipynb
+++ b/Lab2-Computer-Vision.ipynb
@@ -364,11 +364,7 @@
       },
       "source": [
         "####Answer: \n",
-        "The correct answer is (3)\n",
-        "\n",
-        "The output of the model is a list of 10 numbers. These numbers are a probability that the value being classified is the corresponding value, i.e. the first value in the list is the probability that the handwriting is of a '0', the next is a '1' etc. Notice that they are all VERY LOW probabilities.\n",
-        "\n",
-        "For the 7, the probability was .999+, i.e. the neural network is telling us that it's almost certainly a 7."
+        "The correct answer is (3)\n"
       ]
     },
     {


### PR DESCRIPTION
Delete some misleading comments about number classifications  in Lab2-Computer-Vision.ipynb

This should also fix  https://github.com/lmoroney/mlday-tokyo/issues/4

The lab was mentioned in https://youtu.be/bemDFpNooA8